### PR TITLE
fix: changed `bench` output to be compatible with OpenBench

### DIFF
--- a/src/cmd_bench.zig
+++ b/src/cmd_bench.zig
@@ -20,7 +20,7 @@ pub fn run(output: anytype, g: *Game) !void {
         \\bench results:
         \\nodes: {} nodes
         \\time:  {} milliseconds
-        \\nps:   {} nodes per second
+        \\nps:   {} nps
         \\
     , .{
         nodes,


### PR DESCRIPTION
OpenBench's regular expressions for parsing benchmark output were causing the `nps` value to be interpreted as the `nodes` value. See regexr.com/8ag18

Lofty noticed this when trying to recreate one of the OB tests that was failing:
```
Running 15x Benchmarks for no-rfp-on-pv-nodes
[1579721, 1544672, 1504142, 1485845, 1399984, 1403220, 1405889, 1411251, 1417696, 1413770, 1408443, 1385098, 1368051, 1377010, 1354436]
```

Signing off with the previous `bench` value for `main`.

bench: 2773967